### PR TITLE
Replace Copilot with Claude throughout codebase

### DIFF
--- a/multinav/Readme_Usage.txt
+++ b/multinav/Readme_Usage.txt
@@ -164,7 +164,7 @@ Each pane ultimately sends a JSON with:
   "user_input": { "text": "your prompt", "tags": ["multinav"] },
   "task_context": { "topic": "ad-hoc", "intent": "compare" },
   "client": { "surface": "multinav-app", "pane_id": "pane-1", "browser": "electron", "os": "win32", "device": "desktop" },
-  "model": { "provider": "chatgpt|gemini|grok|copilot|...", "name": "best-effort", "mode": "chat" },
+  "model": { "provider": "chatgpt|gemini|grok|claude|...", "name": "best-effort", "mode": "chat" },
   "response": { "text": "assistant reply", "raw_tokens": null, "latency_ms": 1234, "finish_reason": "stop" },
   "observations": { "contains_code": true, "has_citations": false, "ui_broke": false },
   "costing": {}

--- a/multinav/src/preload_view.ts
+++ b/multinav/src/preload_view.ts
@@ -159,9 +159,9 @@ function scrapeGemini(): string | null {
 }
 
 
-// Copilot (copilot.microsoft.com / bing.com/chat)
-function scrapeCopilot(): string | null {
-  const nodes = document.querySelectorAll<HTMLElement>('[aria-live="polite"], .adaptive-card, .contentContainer, .response-message');
+// Claude (claude.ai)
+function scrapeClaude(): string | null {
+  const nodes = document.querySelectorAll<HTMLElement>('[aria-live="polite"], .adaptive-card, .contentContainer, .response-message, [data-testid="message-content"]');
   for (let i = nodes.length - 1; i >= 0; i--) {
     const t = nodes[i].innerText.trim();
     if (t) return t;
@@ -261,8 +261,8 @@ function scrapeGeneric(): string | null {
     oncePerChange(scrapeGemini, emit, { provider: 'gemini' });
     return;
   }
-  if (/copilot\.microsoft\.com|bing\.com/i.test(host)) {
-    oncePerChange(scrapeCopilot, emit, { provider: 'copilot' });
+  if (/claude\.ai/i.test(host)) {
+    oncePerChange(scrapeClaude, emit, { provider: 'claude' });
     return;
   }
 if (/grok\.com|chat\.x\.ai/i.test(host)) {


### PR DESCRIPTION
- Updated scraper function from scrapeCopilot() to scrapeClaude()
- Changed provider URL from copilot.microsoft.com/bing.com to claude.ai
- Updated provider identifier from 'copilot' to 'claude' in all references
- Modified scraper selectors to target Claude's UI elements
- Updated documentation to reflect Claude as the 4th provider

This completes the transition from Copilot to Claude while maintaining the 4-panel layout (ChatGPT, Gemini, Grok, Claude).