### PR TITLE
Add missing preload script APIs for renderer

### DIFF
--- a/multinav/src/preload_control.ts
+++ b/multinav/src/preload_control.ts
@@ -8,8 +8,19 @@ contextBridge.exposeInMainWorld("controlAPI", {
   setLeader: (idx: number | null) => ipcRenderer.invoke("control:setLeader", idx),
   setSprayAll: (on: boolean) => ipcRenderer.invoke("control:setSprayAll", on),
 
-  // send text from control textbox
+  // navigation & view management
+  navigateAll: (url: string) => ipcRenderer.invoke("control:navigateAll", url),
+  navigateOne: (i: number, url: string) => ipcRenderer.invoke("control:navigateOne", i, url),
+  reloadAll: () => ipcRenderer.invoke("control:reloadAll"),
+  setViewCount: (n: number) => ipcRenderer.invoke("control:setViewCount", n),
+
+  // mirror mode controls
+  setMirrorSource: (i: number) => ipcRenderer.invoke("control:setMirrorSource", i),
+  setMirrorEnabled: (on: boolean) => ipcRenderer.invoke("control:setMirrorEnabled", on),
+
+  // input controls
   sendText: (text: string) => ipcRenderer.invoke("control:sendText", text),
+  sendKey: (k: string) => ipcRenderer.invoke("control:sendKey", k),
 
   // optional: pass full prompt for logging/latency
   prompt: (text: string) => ipcRenderer.invoke("control:prompt", text),
@@ -18,10 +29,22 @@ contextBridge.exposeInMainWorld("controlAPI", {
 declare global {
   interface Window {
     controlAPI: {
+      // mode & targeting
       setInputMode: (mode: InputMode) => Promise<void>;
       setLeader: (idx: number | null) => Promise<void>;
       setSprayAll: (on: boolean) => Promise<void>;
+      // navigation & view management
+      navigateAll: (url: string) => Promise<void>;
+      navigateOne: (i: number, url: string) => Promise<void>;
+      reloadAll: () => Promise<void>;
+      setViewCount: (n: number) => Promise<void>;
+      // mirror mode controls
+      setMirrorSource: (i: number) => Promise<void>;
+      setMirrorEnabled: (on: boolean) => Promise<void>;
+      // input controls
       sendText: (text: string) => Promise<void>;
+      sendKey: (k: string) => Promise<void>;
+      // logging/latency tracking
       prompt: (text: string) => Promise<void>;
     };
   }


### PR DESCRIPTION
Added the following missing APIs that the renderer expects:

1. navigateAll(url: string)
   - Purpose: Navigate all browser views to the specified URL
   - Used by: control.ts:40 (Go All button handler)
   - IPC handler: main.ts:305 (control:navigateAll)

2. navigateOne(i: number, url: string)
   - Purpose: Navigate a specific browser view to a URL
   - Used by: control.ts:52 (individual pane navigation)
   - IPC handler: main.ts:309 (control:navigateOne)

3. reloadAll()
   - Purpose: Reload all browser views
   - Used by: control.ts:44 (Reload button handler)
   - IPC handler: main.ts:314 (control:reloadAll)

4. setViewCount(n: number)
   - Purpose: Set the number of visible panes (3 or 4)
   - Used by: control.ts:83, 86 (3-pane/4-pane buttons)
   - IPC handler: main.ts:316 (control:setViewCount)

5. setMirrorSource(i: number)
   - Purpose: Set which pane acts as the mirror source
   - Used by: control.ts:71 (source pane selector)
   - IPC handler: main.ts:321 (control:setMirrorSource)

6. setMirrorEnabled(on: boolean)
   - Purpose: Enable or disable mirror mode
   - Used by: control.ts:77 (mirror toggle button)
   - IPC handler: main.ts:323 (control:setMirrorEnabled)

7. sendKey(k: string)
   - Purpose: Send keyboard key events to all views
   - Used by: control.ts:66 (keyboard button handlers)
   - IPC handler: main.ts:343 (control:sendKey)

Security considerations:
- All APIs use contextBridge.exposeInMainWorld for secure IPC
- All calls use ipcRenderer.invoke (async, secure)
- Follows Electron's contextIsolation best practices
- Maintains sandbox mode for renderer processes

TypeScript definitions updated to include all new methods with proper type safety and Promise return types.