### PR TITLE
fix: Prevent text from disappearing in broadcast input field

### DIFF
--- a/multinav/src/renderer/control.ts
+++ b/multinav/src/renderer/control.ts
@@ -53,11 +53,15 @@ on(document, 'click', '.go-one', async (e) => {
   }
 });
 
-typebox.addEventListener('input', async () => {
-  const t = typebox.value;
-  if (!t) return;
-  await window.controlAPI.sendText(t);
-  typebox.value = '';
+// Send message on Enter (Ctrl+Enter for newline)
+typebox.addEventListener('keydown', async (e) => {
+  if (e.key === 'Enter' && !e.ctrlKey && !e.shiftKey) {
+    e.preventDefault();
+    const t = typebox.value.trim();
+    if (!t) return;
+    await window.controlAPI.sendText(t);
+    typebox.value = '';
+  }
 });
 
 on(document, 'click', '.kbtn', async (e) => {

--- a/multinav/src/renderer/index.html
+++ b/multinav/src/renderer/index.html
@@ -34,7 +34,7 @@
 
     <section class="block">
       <label>Broadcast typing</label>
-      <textarea id="typebox" rows="3" placeholder="Type here to send chars to all panes"></textarea>
+      <textarea id="typebox" rows="3" placeholder="Type message here, press Enter to send to all panes (Ctrl+Enter for newline)"></textarea>
       <div class="row mini gap">
         <button data-k="Tab" class="kbtn">Tab</button>
         <button data-k="Enter" class="kbtn">Enter</button>


### PR DESCRIPTION
Changed the broadcast typebox to only send messages on Enter keypress instead of on every keystroke. This fixes the issue where typed characters immediately vanished as the input event handler was clearing the field after each character.

Changes:
- Replace 'input' event listener with 'keydown' listener
- Only send message when Enter is pressed (not Ctrl+Enter or Shift+Enter)
- Update placeholder text to reflect new behavior
- Text now stays visible until user presses Enter to send